### PR TITLE
Admin path views are now using partials

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,8 +1,9 @@
 class Admin::UsersController < ApplicationController
   before_action :error_unless_admin
   def show
+    @user = User.find(params[:id])
   end
   def index
-    @users = User.where(role: 0)
+    @user = User.where(role: 0)
   end
 end

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,1 +1,2 @@
+<%= render partial: 'users/show' %>
 <%= link_to 'downgrade to user', admin_merchant_path(@user), method: :patch %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,13 +1,13 @@
 <ul>
-  <% @users.each do |user| %>
+  <% @user.each do |current_user| %>
   <li>
-    <%= link_to user.name, admin_user_path(user.id) %>
+    <%= link_to current_user.name, admin_user_path(current_user.id) %>
   </li>
   <li>
-    Registered: <%= user.created_at %>
+    Registered: <%= current_user.created_at %>
   </li>
   <li>
-    <%= link_to "Upgrade #{user.name} to merchant" %>
+    <%= link_to "Upgrade #{current_user.name} to merchant" %>
   </li>
   <% end %>
 </ul>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'users/show' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
       <% elsif merchant_user? %>
         <%= link_to "Dashboard", dashboard_path %>
       <% elsif admin_user? %>
-        <%= link_to "Dashboard", admin_dashboard_path %>
+        <%= link_to "Dashboard", admin_dashboard_path(current_user) %>
         <%= link_to 'Users', admin_users_path %>
       <% end %>
     </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   #admin routes
   namespace :admin do
-    get '/dashboard', to: 'users#show', as: :dashboard
+    get '/dashboard/:id', to: 'users#show', as: :dashboard
     resources :merchants, only: [:show, :update]
     resources :users, only: [:show, :index]
   end

--- a/spec/features/navigation_bar_spec.rb
+++ b/spec/features/navigation_bar_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'navigation bar' do
       expect(page).to_not have_link("Cart", href: cart_path)
 
       click_link "Dashboard"
-      expect(current_path).to eq(admin_dashboard_path)
+      expect(current_path).to eq(admin_dashboard_path(admin))
 
       click_link "Logout"
       expect(current_path).to eq(root_path)

--- a/spec/features/users_cannot_navigate_to_certain_paths_spec.rb
+++ b/spec/features/users_cannot_navigate_to_certain_paths_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'Users cannot navigate to certain paths', type: :feature do
     end
 
     it 'shows 404 error when visiting /admin paths' do
-      visit admin_dashboard_path
+      admin = create(:admin)
+      visit admin_dashboard_path(admin)
       expect(page).to have_http_status(404)
     end
   end
@@ -30,7 +31,8 @@ RSpec.describe 'Users cannot navigate to certain paths', type: :feature do
     end
 
     it 'shows 404 error when visiting /admin paths' do
-      visit admin_dashboard_path
+      admin = create(:admin)
+      visit admin_dashboard_path(admin)
       expect(page).to have_http_status(404)
     end
   end
@@ -52,7 +54,8 @@ RSpec.describe 'Users cannot navigate to certain paths', type: :feature do
     end
 
     it 'shows 404 error when visiting /admin paths' do
-      visit admin_dashboard_path
+      admin = create(:admin)
+      visit admin_dashboard_path(admin)
       expect(page).to have_http_status(404)
     end
   end


### PR DESCRIPTION
- [] Check this if the PR has been approved by the team to be a quick patch and the rest of this form will not be filled out

# Test Coverage Percentage (Model/Feature):
- rspec - 100%
- rspec spec/models - 100%

# What functionality does this accomplish?
Admin path views render partials

# What did you struggle on to complete?
A pathing issue came up, as the admin dashboard is really just another admin user show, so the dashboard hand rolled route needed to have an id attached to it.

# Implements/Fixes:
* description
closes #

# Testing Changes
- [] No Tests have been changed
this-> Some Tests have been changed
Added an admin id to tests that tried to access the admin_dashboard_path without one

- [] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [] My code has no unused/commented out code
- [] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have fully tested my code

# Please include an emoji of how you feel about this branch: