### PR TITLE
Userstory 46 merchant enables an item #26

### DIFF
--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -4,4 +4,13 @@ class Merchants::ItemsController < ApplicationController
     @merchant = current_user
   end
 
+  def enable_item
+    item = Item.find(params[:id])
+    item.update(enabled: true)
+
+    flash[:item_enable_success] = "#{item.name} is now available for sale."
+
+    redirect_to dashboard_items_path
+  end
+
 end

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -18,7 +18,7 @@
       <% if item.enabled %>
         <li><%= link_to "Disable" %></li>
       <% else %>
-        <li><%= link_to "Enable" %></li>
+        <li><%= link_to "Enable", enable_item_path(item) %></li>
       <% end %>
     </ul>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :merchants, only: [:index, :show]
   get '/dashboard', to: 'merchants#show', as: :dashboard
   get '/dashboard/items', to: 'merchants/items#index', as: :dashboard_items
+  get '/enable_item/:id', to: 'merchants/items#enable_item', as: :enable_item
 
   #admin routes
   namespace :admin do

--- a/spec/features/merchants/items_index_spec.rb
+++ b/spec/features/merchants/items_index_spec.rb
@@ -84,5 +84,20 @@ RSpec.describe 'Merchant Items Index Page', type: :feature do
         expect(page).to_not have_link("Enable")
       end
     end
+
+    scenario 'clicking on an item Enable link enables the item' do
+      expect(@inactive_item.enabled).to eq(false)
+
+      within "#merchant-item-#{@inactive_item.id}" do
+        click_link "Enable"
+      end
+
+      expect(current_path).to eq(dashboard_items_path)
+
+      expect(page).to have_content("#{@inactive_item.name} is now available for sale.")
+
+      @inactive_item.reload   # .reload in order to update the object with new database value
+      expect(@inactive_item.enabled).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
- [] Check this if the PR has been approved by the team to be a quick patch and the rest of this form will not be filled out

# Test Coverage Percentage (Model/Feature):
- rspec - 100%
- rspec spec/models - 98.28%

# What functionality does this accomplish?
User Story 46, Merchant enables an item
- Merchants viewing their items index page can now click the link "Enable" which will enable a disabled item.

# What did you struggle on to complete?


# Implements/Fixes:
* description
closes #26 

# Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

# Please include an emoji of how you feel about this branch:
# 😸